### PR TITLE
[INC-1335] Transform iso8601 timestamps to be rfc3339-compliant

### DIFF
--- a/src/metronome/_utils/_transform.py
+++ b/src/metronome/_utils/_transform.py
@@ -230,7 +230,10 @@ def _transform_recursive(
 def _format_data(data: object, format_: PropertyFormat, format_template: str | None) -> object:
     if isinstance(data, (date, datetime)):
         if format_ == "iso8601":
-            return data.isoformat()
+            if data.microsecond == 0:
+                return data.isoformat(sep="T", timespec="seconds").replace("+00:00", "Z")
+            else:
+                return data.isoformat(sep="T", timespec="milliseconds").replace("+00:00", "Z")
 
         if format_ == "custom" and format_template is not None:
             return data.strftime(format_template)

--- a/src/metronome/_utils/_transform.py
+++ b/src/metronome/_utils/_transform.py
@@ -395,7 +395,10 @@ async def _async_transform_recursive(
 async def _async_format_data(data: object, format_: PropertyFormat, format_template: str | None) -> object:
     if isinstance(data, (date, datetime)):
         if format_ == "iso8601":
-            return data.isoformat()
+            if (isinstance(data, datetime)):
+                return data.isoformat(sep="T", timespec="milliseconds").replace("+00:00", "Z")
+            else:
+                return data.isoformat().replace("+00:00", "Z") 
 
         if format_ == "custom" and format_template is not None:
             return data.strftime(format_template)

--- a/src/metronome/_utils/_transform.py
+++ b/src/metronome/_utils/_transform.py
@@ -230,10 +230,10 @@ def _transform_recursive(
 def _format_data(data: object, format_: PropertyFormat, format_template: str | None) -> object:
     if isinstance(data, (date, datetime)):
         if format_ == "iso8601":
-            if data.microsecond == 0:
-                return data.isoformat(sep="T", timespec="seconds").replace("+00:00", "Z")
-            else:
+            if (isinstance(data, datetime)):
                 return data.isoformat(sep="T", timespec="milliseconds").replace("+00:00", "Z")
+            else:
+                return data.isoformat().replace("+00:00", "Z") 
 
         if format_ == "custom" and format_template is not None:
             return data.strftime(format_template)

--- a/src/metronome/_utils/_utils.py
+++ b/src/metronome/_utils/_utils.py
@@ -417,9 +417,6 @@ def json_safe(data: object) -> object:
         return [json_safe(item) for item in data]
 
     if isinstance(data, (datetime, date)):
-        if (isinstance(data, datetime)):
-            return data.isoformat(sep="T", timespec="milliseconds").replace("+00:00", "Z")
-        else:
-            return data.isoformat().replace("+00:00", "Z") 
+        return data.isoformat().replace("+00:00", "Z") 
 
     return data

--- a/src/metronome/_utils/_utils.py
+++ b/src/metronome/_utils/_utils.py
@@ -417,6 +417,9 @@ def json_safe(data: object) -> object:
         return [json_safe(item) for item in data]
 
     if isinstance(data, (datetime, date)):
-        return data.isoformat()
+        if (isinstance(data, datetime)):
+            return data.isoformat(sep="T", timespec="milliseconds").replace("+00:00", "Z")
+        else:
+            return data.isoformat().replace("+00:00", "Z") 
 
     return data

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -189,13 +189,12 @@ class DateModel(BaseModel):
 @pytest.mark.asyncio
 async def test_iso8601_format(use_async: bool) -> None:
     dt = datetime.fromisoformat("2023-02-23T14:16:36.337692+00:00")
-    tz = "Z" if PYDANTIC_V2 else "+00:00"
-    assert await transform({"foo": dt}, DatetimeDict, use_async) == {"foo": "2023-02-23T14:16:36.337692+00:00"}  # type: ignore[comparison-overlap]
-    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337692" + tz}  # type: ignore[comparison-overlap]
+    assert await transform({"foo": dt}, DatetimeDict, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
+    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
 
     dt = dt.replace(tzinfo=None)
-    assert await transform({"foo": dt}, DatetimeDict, use_async) == {"foo": "2023-02-23T14:16:36.337692"}  # type: ignore[comparison-overlap]
-    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337692"}  # type: ignore[comparison-overlap]
+    assert await transform({"foo": dt}, DatetimeDict, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
+    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
 
     assert await transform({"foo": None}, DateDict, use_async) == {"foo": None}  # type: ignore[comparison-overlap]
     assert await transform(DateModel(foo=None), Any, use_async) == {"foo": None}  # type: ignore
@@ -209,7 +208,7 @@ async def test_iso8601_format(use_async: bool) -> None:
 @pytest.mark.asyncio
 async def test_optional_iso8601_format(use_async: bool) -> None:
     dt = datetime.fromisoformat("2023-02-23T14:16:36.337692+00:00")
-    assert await transform({"bar": dt}, DatetimeDict, use_async) == {"bar": "2023-02-23T14:16:36.337692+00:00"}  # type: ignore[comparison-overlap]
+    assert await transform({"bar": dt}, DatetimeDict, use_async) == {"bar": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
 
     assert await transform({"bar": None}, DatetimeDict, use_async) == {"bar": None}
 
@@ -219,7 +218,7 @@ async def test_optional_iso8601_format(use_async: bool) -> None:
 async def test_required_iso8601_format(use_async: bool) -> None:
     dt = datetime.fromisoformat("2023-02-23T14:16:36.337692+00:00")
     assert await transform({"required": dt}, DatetimeDict, use_async) == {
-        "required": "2023-02-23T14:16:36.337692+00:00"
+        "required": "2023-02-23T14:16:36.337Z"
     }  # type: ignore[comparison-overlap]
 
     assert await transform({"required": None}, DatetimeDict, use_async) == {"required": None}
@@ -230,7 +229,7 @@ async def test_required_iso8601_format(use_async: bool) -> None:
 async def test_union_datetime(use_async: bool) -> None:
     dt = datetime.fromisoformat("2023-02-23T14:16:36.337692+00:00")
     assert await transform({"union": dt}, DatetimeDict, use_async) == {  # type: ignore[comparison-overlap]
-        "union": "2023-02-23T14:16:36.337692+00:00"
+        "union": "2023-02-23T14:16:36.337Z"
     }
 
     assert await transform({"union": "foo"}, DatetimeDict, use_async) == {"union": "foo"}
@@ -242,7 +241,7 @@ async def test_nested_list_iso6801_format(use_async: bool) -> None:
     dt1 = datetime.fromisoformat("2023-02-23T14:16:36.337692+00:00")
     dt2 = parse_datetime("2022-01-15T06:34:23Z")
     assert await transform({"list_": [dt1, dt2]}, DatetimeDict, use_async) == {  # type: ignore[comparison-overlap]
-        "list_": ["2023-02-23T14:16:36.337692+00:00", "2022-01-15T06:34:23+00:00"]
+        "list_": ["2023-02-23T14:16:36.337Z", "2022-01-15T06:34:23.000Z"]
     }
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -190,11 +190,11 @@ class DateModel(BaseModel):
 async def test_iso8601_format(use_async: bool) -> None:
     dt = datetime.fromisoformat("2023-02-23T14:16:36.337692+00:00")
     assert await transform({"foo": dt}, DatetimeDict, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
-    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
+    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337692Z"}  # type: ignore[comparison-overlap]
 
     dt = dt.replace(tzinfo=None)
-    assert await transform({"foo": dt}, DatetimeDict, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
-    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337Z"}  # type: ignore[comparison-overlap]
+    assert await transform({"foo": dt}, DatetimeDict, use_async) == {"foo": "2023-02-23T14:16:36.337"}  # type: ignore[comparison-overlap]
+    assert await transform(DatetimeModel(foo=dt), Any, use_async) == {"foo": "2023-02-23T14:16:36.337692"}  # type: ignore[comparison-overlap]
 
     assert await transform({"foo": None}, DateDict, use_async) == {"foo": None}  # type: ignore[comparison-overlap]
     assert await transform(DateModel(foo=None), Any, use_async) == {"foo": None}  # type: ignore


### PR DESCRIPTION
Our OpenAPI spec uses "date-time" as a format, which requires RFC3339-formatted timestamps. RFC3339 timestamps are a restricted subset of ISO8601 timestamps and by default python isoformat is not RFC3339 compliant. This updates the stainless generation code to properly transform python datetimes into RFC3339-compliant timestamps.


